### PR TITLE
Make jQuery optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Rack Middleware that embeds the Konami Code in your app and lets you fade in and
 
 * Updated for compatibility with Ruby 3 and Rack 3
 
-## Requirements 
-It requires JQuery 1.4.0 or greater.
+## Requirements
+Works with jQuery 1.4.0 or greater but falls back to vanilla JavaScript when jQuery isn't available.
 
 ## Usage
 

--- a/lib/rack_konami.rb
+++ b/lib/rack_konami.rb
@@ -13,11 +13,17 @@ module Rack
     x:y;result=this.tap==true?"TAP":result;if(result==this.keys[0])this.keys=this.keys.slice(1,this.keys.length);if(this.keys.length==0){this.keys=this.orig_keys;this.code(b)}}}};return a};
     </script>
     <script type="text/javascript">
-    	konami = new Konami()
-    	konami.code = function() {
-        $('#rack_konami').fadeIn('slow').delay({{DELAY}}).fadeOut('slow');
-      }
-    	konami.load()
+        konami = new Konami()
+        konami.code = function() {
+          var elem = document.getElementById('rack_konami');
+          if (window.jQuery) {
+            jQuery(elem).fadeIn('slow').delay({{DELAY}}).fadeOut('slow');
+          } else {
+            elem.style.display = 'block';
+            setTimeout(function() { elem.style.display = 'none'; }, {{DELAY}});
+          }
+        }
+        konami.load()
     </script>
     EOTC
 

--- a/rack_konami.gemspec
+++ b/rack_konami.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.email       = ["mark@amerine.net"]
   s.homepage    = ""
   s.summary     = %q{Rack middlware that embeds the Konami code in your apps}
-  s.description = %q{Mixes the Konami code + JQuery to add Konami code effects to your app}
+  s.description = %q{Mixes the Konami code with JavaScript to add Konami code effects to your app. Uses jQuery when available.}
 
   s.rubyforge_project = "rack_konami"
 


### PR DESCRIPTION
## Summary
- support vanilla JS fallback when jQuery is missing
- clarify jQuery optional in README
- update gemspec description

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6878d348b1208325822c94703faf5063